### PR TITLE
StartTLS support without cert for LDAP authenticator

### DIFF
--- a/Authenticators/LDAP/LDAPauth.ini
+++ b/Authenticators/LDAP/LDAPauth.ini
@@ -35,6 +35,9 @@ group_attr = uniqueMember
 ; Uncomment to provide list of registered users from LDAP
 ; provide_users = true
 
+; Uncomment to use StartTLS without cert check
+; use_start_tls = true
+
 ;Murmur configuration
 [murmur]
 ;List of virtual server IDs, empty = all

--- a/Authenticators/LDAP/LDAPauth.ini
+++ b/Authenticators/LDAP/LDAPauth.ini
@@ -30,13 +30,13 @@ display_attr = displayName
 group_cn = cn=mumble,ou=Groups,dc=example,dc=com
 group_attr = uniqueMember
 ; Uncomment and set below to provide more info from LDAP
-; provide_info = true
+; provide_info = True
 ; mail_attr = mail
 ; Uncomment to provide list of registered users from LDAP
-; provide_users = true
+; provide_users = True
 
 ; Uncomment to use StartTLS without cert check
-; use_start_tls = true
+; use_start_tls = True
 
 ;Murmur configuration
 [murmur]

--- a/Authenticators/LDAP/LDAPauth.py
+++ b/Authenticators/LDAP/LDAPauth.py
@@ -455,12 +455,16 @@ def do_main_program():
                 # change trace (second param) to 1 instead of 0 to see more trace
 
             if cfg.ldap.use_start_tls:
-	        # try StartTLS: connection specific options
-	        debug('use_start_tls is set, setting connection options X_TLS_*')
-	        ldap_conn.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
-	        ldap_conn.set_option(ldap.OPT_X_TLS,ldap.OPT_X_TLS_DEMAND)
-	        ldap_conn.set_option(ldap.OPT_X_TLS_DEMAND, True)
-	        ldap_conn.start_tls_s()
+                # try StartTLS: connection specific options
+                debug('use_start_tls is set, setting connection options X_TLS_*')
+                ldap_conn.set_option(ldap.OPT_PROTOCOL_VERSION, 3)
+                ldap_conn.set_option(ldap.OPT_X_TLS, ldap.OPT_X_TLS_DEMAND)
+                ldap_conn.set_option(ldap.OPT_X_TLS_DEMAND, True)
+                try:
+                    ldap_conn.start_tls_s()
+                except Exception, e:
+                    warning('could not initiate StartTLS, e = ' + str(e))
+                    return (AUTH_REFUSED, None, None)
 
             if cfg.ldap.bind_dn:
                 # Bind the functional account to search the directory.


### PR DESCRIPTION
This change will add an option to enable StartTLS without cert check for the LDAP authenticator. The default is not to use StartTLS. You can enable it by uncommenting the line `use_start_tls = true` in "LDAPAuth.ini".