### PR TITLE
Add specific version of python to shebang line

### DIFF
--- a/Authenticators/Elkarte/elkarteauth.py
+++ b/Authenticators/Elkarte/elkarteauth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010, Stefan Hacker <dd0t@users.sourceforge.net>

--- a/Authenticators/LDAP/LDAPauth.py
+++ b/Authenticators/LDAP/LDAPauth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # Copyright (C) 2011 Benjamin Jemlich <pcgod@user.sourceforge.net>
 # Copyright (C) 2011 Nathaniel Kofalt <nkofalt@users.sourceforge.net>

--- a/Authenticators/SMF/1.x/smfauth.py
+++ b/Authenticators/SMF/1.x/smfauth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/Authenticators/SMF/2.0/smfauth.py
+++ b/Authenticators/SMF/2.0/smfauth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/Authenticators/phpBB3/phpBB3auth.py
+++ b/Authenticators/phpBB3/phpBB3auth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2009-2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/Helpers/mice.py
+++ b/Helpers/mice.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2008 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/Helpers/modmurmur.py
+++ b/Helpers/modmurmur.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 
 # Copyright (C) 2010 Stefan Hacker <dd0t@users.sourceforge.net>

--- a/Monitoring/munin-murmur.py
+++ b/Monitoring/munin-murmur.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 #
 # munin-murmur.py

--- a/Non-RPC/MumBo/MumBo.py
+++ b/Non-RPC/MumBo/MumBo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 # kate: space-indent on; indent-width 4; replace-tabs on;
 

--- a/Non-RPC/eveBot/eve-bot.py
+++ b/Non-RPC/eveBot/eve-bot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #Copyright (c) 2009, Philip Cass <frymaster@127001.org>
 #Copyright (c) 2009, Alan Ainsworth <fruitbat@127001.org>

--- a/Non-RPC/mumble-ping.py
+++ b/Non-RPC/mumble-ping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8
 # Based on pcgod's mumble-ping script found at http://0xy.org/mumble-ping.py.
 


### PR DESCRIPTION
Python3, which is the default on some systems, won't run these files. Specifying python2 in the shebang will allow them to be run using ./ notation instead of constantly specifying python2 for each program.
