### PR TITLE
Fix reporting duplicate mute users

### DIFF
--- a/Monitoring/munin-murmur.py
+++ b/Monitoring/munin-murmur.py
@@ -153,13 +153,9 @@ for key in onlineusers.keys():
   if onlineusers[key].userid > 0:
     users_registered += 1
 
-  if onlineusers[key].mute:
-    users_muted += 1
-
-  if onlineusers[key].selfMute:
-    users_muted += 1
-
-  if onlineusers[key].suppress:
+  if onlineusers[key].mute \
+      or onlineusers[key].selfMute \
+      or onlineusers[key].suppress:
     users_muted += 1
 
 # Output the date to munin...


### PR DESCRIPTION
Now a user who is self-muted and suppressed will only add one to the
muted user count.
